### PR TITLE
Badges URL for Linter Results

### DIFF
--- a/web-ui/src/client/app/containers/app.jsx
+++ b/web-ui/src/client/app/containers/app.jsx
@@ -36,7 +36,7 @@ export function App(props) {
       />
       <Route
         path="/"
-        render={props => (
+        render={() => (
           <div>
             <div className="main-navigation-bar">
               <h1 className="dc-h1 main-navigation-bar__title">

--- a/web-ui/src/client/app/containers/app.jsx
+++ b/web-ui/src/client/app/containers/app.jsx
@@ -4,6 +4,7 @@ import UserInfo from '../components/user-info.jsx';
 
 import { Login } from './login.jsx';
 import { ViolationsTab } from './violations-tab.jsx';
+import { Badge } from './badge.jsx';
 
 export function App(props) {
   const {
@@ -22,77 +23,105 @@ export function App(props) {
   const MOUNTPATH = env.MOUNTPATH || '/';
 
   return (
-    <div>
-      <div className="main-navigation-bar">
-        <h1 className="dc-h1 main-navigation-bar__title">
-          <Link to="/" className="main-navigation-bar__link">
-            <img
-              className="main-navigation-bar__logo"
-              src={MOUNTPATH + 'assets/logo.png'}
-            />
-            SBB's API Linter
-          </Link>{' '}
-          <Link to="https://www.sbb.ch" className="main-navigation-bar__link">
-            <img className="sbb-logo" src={MOUNTPATH + 'assets/SBB.svg'} />
-          </Link>{' '}
-        </h1>
-        {OAUTH_ENABLED === true ? (
-          <UserInfo
-            username={user.username}
-            authenticated={user.authenticated}
-            onLogin={login}
-            onLogout={logout}
+    <Switch>
+      <Route
+        exact
+        path="/badges/:externalId"
+        render={props => (
+          <Badge
+            getApiViolationsByExternalId={getApiViolationsByExternalId}
+            {...props}
           />
-        ) : null}
-      </div>
-      <div className="dc-page page-container">
-        <Switch>
-          <Route
-            path="/login"
-            render={props => <Login user={user} login={login} {...props} />}
-          />
-          <Route
-            render={props => (
-              <ViolationsTab
-                authenticated={user.authenticated || !OAUTH_ENABLED}
-                getSupportedRules={getSupportedRules}
-                getApiViolationsByURL={getApiViolationsByURL}
-                getApiViolationsBySchema={getApiViolationsBySchema}
-                getApiViolationsByExternalId={getApiViolationsByExternalId}
-                getFile={getFile}
-                Storage={Storage}
-                {...props}
-              />
-            )}
-          />
-        </Switch>
-      </div>
-      <footer>
-        <a
-          className="dc-link"
-          href="https://github.com/schweizerischebundesbahnen/zally"
-          target="_blank"
-        >
-          Github Project
-        </a>{' '}
-        - An SBB customised fork of Zaland's awesome{' '}
-        <a
-          className="dc-link"
-          href="https://github.com/zalando/zally"
-          target="_blank"
-        >
-          Zally
-        </a>
-        {', '}
-        which is open sourced under{' '}
-        <a
-          className="dc-link"
-          href="https://github.com/zalando/zally/blob/master/LICENSE"
-          target="_blank"
-        >
-          ZALANDO's License
-        </a>{' '}
-      </footer>
-    </div>
+        )}
+      />
+      <Route
+        path="/"
+        render={props => (
+          <div>
+            <div className="main-navigation-bar">
+              <h1 className="dc-h1 main-navigation-bar__title">
+                <Link to="/" className="main-navigation-bar__link">
+                  <img
+                    className="main-navigation-bar__logo"
+                    src={MOUNTPATH + 'assets/logo.png'}
+                  />
+                  SBB's API Linter
+                </Link>{' '}
+                <Link
+                  to="https://www.sbb.ch"
+                  className="main-navigation-bar__link"
+                >
+                  <img
+                    className="sbb-logo"
+                    src={MOUNTPATH + 'assets/SBB.svg'}
+                  />
+                </Link>{' '}
+              </h1>
+              {OAUTH_ENABLED === true ? (
+                <UserInfo
+                  username={user.username}
+                  authenticated={user.authenticated}
+                  onLogin={login}
+                  onLogout={logout}
+                />
+              ) : null}
+            </div>
+            <div className="dc-page page-container">
+              <Switch>
+                <Route
+                  path="/login"
+                  render={props => (
+                    <Login user={user} login={login} {...props} />
+                  )}
+                />
+                <Route
+                  render={props => (
+                    <ViolationsTab
+                      authenticated={user.authenticated || !OAUTH_ENABLED}
+                      getSupportedRules={getSupportedRules}
+                      getApiViolationsByURL={getApiViolationsByURL}
+                      getApiViolationsBySchema={getApiViolationsBySchema}
+                      getApiViolationsByExternalId={
+                        getApiViolationsByExternalId
+                      }
+                      getFile={getFile}
+                      Storage={Storage}
+                      {...props}
+                    />
+                  )}
+                />
+              </Switch>
+            </div>
+            <footer>
+              <a
+                className="dc-link"
+                href="https://github.com/schweizerischebundesbahnen/zally"
+                target="_blank"
+              >
+                Github Project
+              </a>{' '}
+              - An SBB customised fork of Zaland's awesome{' '}
+              <a
+                className="dc-link"
+                href="https://github.com/zalando/zally"
+                target="_blank"
+              >
+                Zally
+              </a>
+              {', '}
+              which is open sourced under{' '}
+              <a
+                className="dc-link"
+                href="https://github.com/zalando/zally/blob/master/LICENSE"
+                target="_blank"
+              >
+                ZALANDO's License
+              </a>{' '}
+            </footer>
+          </div>
+        )}
+      />
+      <redirect path="*" to="/" />
+    </Switch>
   );
 }

--- a/web-ui/src/client/app/containers/badge.jsx
+++ b/web-ui/src/client/app/containers/badge.jsx
@@ -1,5 +1,4 @@
-import React, { Component } from 'react';
-import { Redirect } from 'react-router-dom';
+import React from 'react';
 import { Violations } from './violations.jsx';
 
 export function ShieldsBadge(props) {
@@ -70,7 +69,7 @@ export class Badge extends Violations {
   }
 
   calculateScore(violationsCount) {
-    var score = 1.0;
+    let score = 1.0;
     score = score - Math.min(0.8, violationsCount.must * 0.2);
     score = score - Math.min(0.15, violationsCount.should * 0.05);
     score = score - Math.min(0.05, violationsCount.may * 0.01);

--- a/web-ui/src/client/app/containers/badge.jsx
+++ b/web-ui/src/client/app/containers/badge.jsx
@@ -1,0 +1,89 @@
+import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
+import { Violations } from './violations.jsx';
+
+export function ShieldsBadge(props) {
+  if ('MUST' === props.type)
+    return <span className="dc-status dc-status--error" />;
+  else if ('SHOULD' === props.type)
+    return <span className="dc-status dc-status--new" />;
+  else return <span className="dc-status dc-status--inactive" />;
+}
+
+export class Badge extends Violations {
+  constructor(props) {
+    super(props);
+    if (
+      props &&
+      props.match &&
+      props.match.params &&
+      props.match.params.externalId
+    ) {
+      this.state.externalId = props.match.params.externalId;
+    } else {
+      this.state.externalId = null;
+    }
+  }
+
+  componentDidMount() {
+    if (this.state.externalId) {
+      this.getApiViolationsByExternalId(this.state.externalId)
+        .then(response => {
+          const score = this.calculateScore(response.violations_count);
+          const color = score < 80 ? (score < 50 ? 'red' : 'orange') : 'green';
+          const shieldsBaseUrl =
+            'https://img.shields.io/badge/API%20Linter%20Score-';
+          const shieldsUrl = shieldsBaseUrl.concat(score, '%25-', color);
+          const urlToResult = window.location.protocol.concat(
+            '//',
+            window.location.host,
+            '/editor/',
+            this.state.externalId
+          );
+          this.setState({
+            pending: false,
+            ajaxComplete: true,
+            externalId: response.external_id,
+            violations: response.violations,
+            violationsCount: response.violations_count,
+            shieldsUrl: shieldsUrl,
+            urlToResult: urlToResult,
+          });
+        })
+        .catch(error => {
+          console.error(error); // eslint-disable-line no-console
+          this.setState({
+            pending: false,
+            ajaxComplete: true,
+            error: error.detail || Violations.DEFAULT_ERROR_MESSAGE,
+            violations: [],
+            violationsCount: {
+              could: 0,
+              hint: 0,
+              must: 0,
+              should: 0,
+            },
+          });
+          return Promise.reject(error);
+        });
+    }
+  }
+
+  calculateScore(violationsCount) {
+    var score = 1.0;
+    score = score - Math.min(0.8, violationsCount.must * 0.2);
+    score = score - Math.min(0.15, violationsCount.should * 0.05);
+    score = score - Math.min(0.05, violationsCount.may * 0.01);
+    return Math.round(score * 100);
+  }
+
+  render() {
+    return (
+      <div>
+        <a href={this.state.urlToResult}>
+          <img src={this.state.shieldsUrl} />
+        </a>
+      </div>
+    );
+  }
+}

--- a/web-ui/src/client/app/containers/editor.jsx
+++ b/web-ui/src/client/app/containers/editor.jsx
@@ -4,7 +4,6 @@ import { Violations } from './violations.jsx';
 import { ViolationsResult } from '../components/violations.jsx';
 import { EditorInputForm } from '../components/editor.jsx';
 import { Dialog } from '../components/dialog.jsx';
-import { id } from 'brace/worker/json';
 
 export const editorErrorToAnnotations = error => {
   if (!error || !error.mark) {


### PR DESCRIPTION
Adding /badges/:externalId URL, which presents an embeddable badge for the linter result.

<img width="698" alt="image" src="https://user-images.githubusercontent.com/9402842/97308098-c2db2180-1860-11eb-9b7e-84ecdb870168.png">

